### PR TITLE
ififuncs - add DV to recursive_file_list()

### DIFF
--- a/ififuncs.py
+++ b/ififuncs.py
@@ -1471,7 +1471,7 @@ def recursive_file_list(video_files):
     recursive_list = []
     for root, _, filenames in os.walk(video_files):
         for filename in filenames:
-            if filename.endswith(('.MP4', '.mp4', '.mov', '.mkv', '.mxf', '.MXF', '.WAV', '.wav', '.aiff', '.AIFF', 'mp3', 'MP3', 'm2t')):
+            if filename.endswith(('.MP4', '.mp4', '.mov', '.mkv', '.mxf', '.MXF', '.WAV', '.wav', '.aiff', '.AIFF', 'mp3', 'MP3', 'm2t', '.dv', '.DV')):
                 recursive_list.append(os.path.join(root, filename))
     return recursive_list
 


### PR DESCRIPTION
Ok, so it turned out that the issue seems to just be that DV was not in the list of file types that ififuncs uses to generate a list of files to process. I only did some basic testing but blaa.csv had actual tech metadata, so @hyz2993  can you do better testing, like running the batchaccession job and seeing if this is enough to fix the issue? Still have zero idea why it didn't just crash for Yujing and instead just make an incomplete CSV. Perhaps there's more to this than meets the eye..