### PR TITLE
sipcreator.py - add atexit.register for remaining manifest in the desktop manifest dir

### DIFF
--- a/scripts/sipcreator.py
+++ b/scripts/sipcreator.py
@@ -11,6 +11,7 @@ import sys
 import shutil
 import datetime
 import time
+import atexit
 import copyit
 import ififuncs
 import package_update
@@ -26,6 +27,22 @@ try:
 except ImportError:
     print('Clairmeta is not installed. DCP options will not function!')
 
+@atexit.register
+def clear_manifest_dir():
+    '''
+    This function prevent "moveit_manifests" folder has imcompleted 
+    manifest file inside and mess the incoming process.
+    It will move existed manifest file into the "moveit_manifests/old_manifests"
+    '''
+    desktop_manifest_dir = os.path.expanduser("~/Desktop/moveit_manifests")
+    old_manifest_dir = os.path.join(desktop_manifest_dir, 'old_manifests')
+    for i in os.listdir(desktop_manifest_dir):
+        o = os.path.join(old_manifest_dir, i)
+        i = os.path.join(desktop_manifest_dir, i)
+        if i.endswith('.md5'):
+            print('**** Found existing manifest: ' + i)
+            shutil.move(i, o)
+            print('**** Moved to old_manifest folder')
 
 def make_folder_path(path, args, object_entry):
     '''


### PR DESCRIPTION
**Background**
a manifest created by sipcreator.py with special collection material will have both parts of the previous files and the current files IF THE PREVIOUS SIPCREATOR.PY STOPPES DURING PROCESSING, which will cause the current validation to get wrong (files shown in the manifest are not in the local directory).
 
 ![image](https://github.com/Irish-Film-Institute/IFIscripts/assets/55084036/12d782a5-0636-4815-9373-15d8665a6a88)

The screenshot above is the "moveit_manifest" folder on the desktop. It is like a transit station (sorry I think I used the wrong word in the meeting) for scripts making manifest. The script will make the manifest here. At the end of running, the script will copy it to the target folder (ie. sip folder) and move it to the "old_manifests" folder as shown in that folder.
So "old_manifests" stores manifests generated during the pre-existed sipcreator.py or other scripts need to generate one.

Problem: then we can find - if the script stops by accident during processing, the manifest will only stay in the "moveit_manifest".
 
![image](https://github.com/Irish-Film-Institute/IFIscripts/assets/55084036/1b5f0d83-2eec-46a3-ab12-8b734c2556d9)

Here I have made a simulated disk like special collection deliveries. The materials are stored in the root of the disk. The file path here will be (ie.): D:\KIN101_Credits.docx. Because there is no folder between the disk and the file, sipcreator.py will therefore name the manifest by default as "**object**_manifest.md5". Also, it means sipcreator.py will name all the manifests from special collection "**object**_manifest.md5".
Problem: now we can find, if the script for specially collection stops by accident during processing, that object_manifest.md5 will keep there. And if the user starts run the next, then the manifest will have both the last files and the current files together in one file. And that will cause a false alarm of file exists in the manifest but missing in the local directory.

---
**Solution**
I imported atexit module in sipcreator.py and let a clean-up run whenever the script stops. This has been tested on Windows and worked fine. The layout is like below:
```
C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts>sipcreator.py -sc -i D: -o E:\oe12345
......
100%        New File               37454        KIN107_Credits.docx
100%        New File              291430        KIN107_Synopsis.docx
100%        New File               36718        KIN108_Credits.docx
100%        New File              291444        KIN108_Synopsis.docx
100%        New File               22824        KINS01_BIOGRAPHIES.docx
100%        New File              291741        KINS01_Captions.docx
100%        New File              338478        KINS01_PressKit.docx
100%        New File              39.4 m        KINS01_Still_001.tiff
 25.3%Traceback (most recent call last):        KINS01_Still_002.tiff
  File "C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts\sipcreator.py", line 628, in <module>
    main(sys.argv[1:])
  File "C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts\sipcreator.py", line 533, in main
    log_names = move_files(inputs, sip_path, args, user)
  File "C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts\sipcreator.py", line 135, in move_files
    log_name = copyit.main(cmd)
  File "C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts\copyit.py", line 717, in main
    copy_dir(
  File "C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts\copyit.py", line 198, in copy_dir
    subprocess.call([
  File "C:\Users\yazhou.he\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 347, in call
    return p.wait(timeout=timeout)
  File "C:\Users\yazhou.he\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 1209, in wait
    return self._wait(timeout=timeout)
  File "C:\Users\yazhou.he\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 1490, in _wait
    result = _winapi.WaitForSingleObject(self._handle,
KeyboardInterrupt
**** Found existing manifest: C:\Users\yazhou.he/Desktop/moveit_manifests\objects_manifest.md5
**** Moved to old_manifest folder
^C
C:\Users\yazhou.he\ifigit\ifiscripts_yhe\scripts>
```
