### PR TITLE
batchaccession.py, ififuncs.py - utf-8 fixes

### DIFF
--- a/scripts/batchaccession.py
+++ b/scripts/batchaccession.py
@@ -58,7 +58,7 @@ def gather_metadata(source):
         ififuncs.make_desktop_logs_dir(),
         time.strftime("%Y-%m-%dT%H_%M_%S_pbcore.csv")
     )
-    with open(collated_pbcore, 'w') as fo:
+    with open(collated_pbcore, 'w', encoding='utf-8') as fo:
         for i in metadata:
             fo.write(i[0])
     return collated_pbcore

--- a/scripts/ififuncs.py
+++ b/scripts/ififuncs.py
@@ -561,7 +561,7 @@ def create_csv(csv_file, *args):
 
 
 def append_csv(csv_file, *args):
-    f = open(csv_file, 'a', newline='')
+    f = open(csv_file, 'a', encoding='utf-8', newline='')
     try:
         writer = csv.writer(f)
         writer.writerow(*args)


### PR DESCRIPTION
This update is for the issue found that the value of Donor (question of source of acquisition in batchaccession.py) with Irish Character will print "�" into the objects metadata/pbcore and ifiscripts_log/pbcore.

It has been tested and works fine.

Thanks again for the expertise from Niamh in the #24!