### PR TITLE
as11fixity.py - add block for -MediaConchReport.xml, update dir walking structure, add  checksums display in the terminal

### DIFF
--- a/scripts/as11fixity.py
+++ b/scripts/as11fixity.py
@@ -217,7 +217,8 @@ def main():
             if xml_flag == 0:
                 print(dirpath + '\n*****There is no metadata xml file in the supplement directory!\n*****Check if the structure is correct.\n---')
                 continue
-    print("Report complete - Time elaspsed : ", datetime.now() - startTime)
+    print("Report complete\nTime elaspsed : ", datetime.now() - startTime)
+    print("Location: " + csv_report)
 
 
 if __name__ == '__main__':

--- a/scripts/as11fixity.py
+++ b/scripts/as11fixity.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 '''
-WORK IN PROGRESS WORKSHOP SCRIPT!!!
+VALIDATE AS-11 UK DPP MXF BY COMPARING 
+ITS CHECKSUMS FROM BOTH PACKAGE MANIFEST
+AND DPP XML <MediaChecksumValue>
 '''
 
 import sys
@@ -41,8 +43,8 @@ def count_files(starting_dir):
         aaa = False
         try:
             current_oe = dirpath.split('oe')[1][:5]
-            if current_oe[-1] == '/':
-                current_oe = current_oe[:4]
+            if current_oe[-1] == '/' or current_oe[-1] == '\\':
+                current_oe = current_oe[:-1]
             oe = True
         except IndexError:
             try:
@@ -67,17 +69,21 @@ def count_files(starting_dir):
             print 'hi'
             dicto['aaa' + previous_oe] = [filename_counter, dir_counter]
         '''
-    print(dicto)
+    print('SIP/AIP found:')
+    for i in dicto:
+        print(i, " | filecount: ", dicto[i][0], " | folder_count: ", dicto[i][1])
+    print()
     return dicto
+
 def main():
     starting_dir = sys.argv[1]
     dicto = count_files(starting_dir)
-    print(dicto, 12312312123)
     startTime = datetime.now()
     csv_report_filename = os.path.basename(starting_dir) + "_report"
     csv_report = os.path.expanduser("~/Desktop/%s.csv") % csv_report_filename
     checkfile = os.path.isfile(csv_report)
-    counter = 0
+    if checkfile is True:
+        print("CSV file already exists.\nThis will overwrite the existed CSV.\n")
     ififuncs.create_csv(
         csv_report,
         (
@@ -93,120 +99,124 @@ def main():
             'Md5_From_Xml',
             'Md5_from_Mxf',
             'Checksum_Result'
-            )
         )
-    if checkfile is True:
-        print("CSV file already exists.")
+    )
+    
+    xml_flag = 0
     for dirpath, dirss, filenames in sorted(os.walk(starting_dir)):
-        for filename in filenames:
-            if filename.endswith('.xml'):
-                if os.path.basename(dirpath) == 'supplemental':
+        if len(os.path.basename(dirpath)) == 36:
+            uuid_dir = dirpath
+            logs_dir = os.path.join(uuid_dir, 'logs')
+            log = os.path.join(logs_dir, os.path.basename(uuid_dir) + '_sip_log.log')
+            objects_dir = os.path.join(uuid_dir, 'objects')
+            objects_list = os.listdir(objects_dir)
+            manifest_basename = os.path.basename(uuid_dir) + '_manifest.md5'
+            manifest = os.path.join(os.path.dirname(uuid_dir), manifest_basename)
+        if os.path.basename(dirpath) == 'supplemental':
+            for filename in filenames:
+                if filename.endswith('.xml') and not filename.endswith('_MediaConchReport.xml'):
                     full_xml_path = os.path.join(dirpath, filename)
+                    xml_flag = 1
+                    with open(manifest, 'r', encoding='utf-8') as fo:
+                        manifest_lines = fo.readlines()
+                        for line in manifest_lines:
+                            if line.lower().replace('\n', '').endswith('.mxf'):
+                                mxf_checksum = line[:32]
+                                #mxf_checksum = str(digest_with_progress(mxf, 1024))
+                                print(mxf_checksum + ' - mxf checksum from package manifest')
+                    try:
+                        dpp_xml_parse = etree.parse(full_xml_path)
+                        dpp_xml_namespace = dpp_xml_parse.xpath('namespace-uri(.)')
+                        #parsed values from dpp xml
+                        series_title = dpp_xml_parse.findtext(
+                            '//ns:SeriesTitle',
+                            namespaces={'ns':dpp_xml_namespace}
+                        )
+                        prog_title = dpp_xml_parse.findtext(
+                            '//ns:ProgrammeTitle',
+                            namespaces={'ns':dpp_xml_namespace}
+                        )
+                        ep_num = dpp_xml_parse.findtext(
+                            '//ns:EpisodeTitleNumber',
+                            namespaces={'ns':dpp_xml_namespace}
+                        )
+                        checksum = dpp_xml_parse.findtext(
+                            '//ns:MediaChecksumValue',
+                            namespaces={'ns':dpp_xml_namespace}
+                        )
+                        print(checksum + ' - mxf checksum from DPP XML')
+                        accession_number_id = ''
+                        if os.path.isfile(log):
+                            with open(log, 'r', encoding='utf-8') as log_object:
+                                log_lines = log_object.readlines()
+                                for lines in log_lines:
+                                    if 'eventIdentifierType=object entry,' in lines:
+                                        source_oe = lines.split('=')[-1].replace('\n', '')
+                                    if 'eventIdentifierType=accession number,' in lines:
+                                        accession_number_id = lines.split('=')[-1].replace('\n', '')
+                        print('Generating Report.... ')
+                        if mxf_checksum == checksum:
+                            print(source_oe + 'Checksum MATCHES!\n---')
+                            ififuncs.append_csv(
+                                csv_report,
+                                (
+                                    os.path.basename(os.path.dirname(uuid_dir)),
+                                    source_oe,
+                                    accession_number_id,
+                                    dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
+                                    dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
+                                    filename,
+                                    unidecode.unidecode(series_title),
+                                    unidecode.unidecode(prog_title),
+                                    unidecode.unidecode(ep_num),
+                                    checksum,
+                                    mxf_checksum,
+                                    'CHECKSUM MATCHES!'
+                                    )
+                            )
+                        else:
+                            print(source_oe + 'Checksum does NOT MATCH!\n---'),
+                            ififuncs.append_csv(
+                                csv_report,
+                                (
+                                    os.path.basename(os.path.dirname(uuid_dir)),
+                                    source_oe,
+                                    accession_number_id,
+                                    dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
+                                    dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
+                                    filename,
+                                    unidecode.unidecode(series_title),
+                                    unidecode.unidecode(prog_title),
+                                    unidecode.unidecode(ep_num),
+                                    checksum,
+                                    mxf_checksum,
+                                    'CHECKSUM DOES NOT MATCH!'
+                                    )
+                            )
+                    except AttributeError:
+                        print(source_oe + 'Checksum does NOT MATCH or wrong source!\n---')
+                        ififuncs.append_csv(
+                            csv_report,
+                            (
+                                os.path.basename(os.path.dirname(uuid_dir)),
+                                source_oe,
+                                accession_number_id,
+                                dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
+                                dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
+                                filename,
+                                'error',
+                                'error',
+                                'error',
+                                'error',
+                                'error',
+                                'CHECKSUM DOES NOT MATCH or WRONG SOURCE!'
+                                )
+                            )
                 else:
                     continue
-                uuid_dir = os.path.dirname(os.path.dirname(dirpath))
-                objects_dir = os.path.join(uuid_dir, 'objects')
-                logs_dir = os.path.join(uuid_dir, 'logs')
-                log = os.path.join(logs_dir, os.path.basename(uuid_dir) + '_sip_log.log')
-                
-                objects_list = os.listdir(objects_dir)
-
-                manifest_basename = os.path.basename(uuid_dir) + '_manifest.md5'
-                manifest = os.path.join(os.path.dirname(uuid_dir), manifest_basename)
-                with open(manifest, 'r', encoding='utf-8') as fo:
-                    manifest_lines = fo.readlines()
-                    for line in manifest_lines:
-                        if line.lower().replace('\n', '').endswith('.mxf'):
-                        
-                            mxf_checksum = line[:32]
-                            print(mxf_checksum)
-                #mxf_checksum = str(digest_with_progress(mxf, 1024))
-                try:
-                    dpp_xml_parse = etree.parse(full_xml_path)
-                    dpp_xml_namespace = dpp_xml_parse.xpath('namespace-uri(.)')
-                    #parsed values
-                    series_title = dpp_xml_parse.findtext(
-                        '//ns:SeriesTitle',
-                        namespaces={'ns':dpp_xml_namespace}
-                    )
-                    prog_title = dpp_xml_parse.findtext(
-                        '//ns:ProgrammeTitle',
-                        namespaces={'ns':dpp_xml_namespace}
-                    )
-                    ep_num = dpp_xml_parse.findtext(
-                        '//ns:EpisodeTitleNumber',
-                        namespaces={'ns':dpp_xml_namespace}
-                    )
-                    checksum = dpp_xml_parse.findtext(
-                        '//ns:MediaChecksumValue',
-                        namespaces={'ns':dpp_xml_namespace}
-                    )
-                    accession_number_id = ''
-                    print('Generating Report....  \n')
-                    if os.path.isfile(log):
-                        print(log)
-                        with open(log, 'r', encoding='utf-8') as log_object:
-                            log_lines = log_object.readlines()
-                            for lines in log_lines:
-                                if 'eventIdentifierType=object entry,' in lines:
-                                    source_oe = lines.split('=')[-1].replace('\n', '')
-                                if 'eventIdentifierType=accession number,' in lines:
-                                    accession_number_id = lines.split('=')[-1].replace('\n', '')
-                    if mxf_checksum == checksum:
-                        print(dicto,7897897897)
-                        ififuncs.append_csv(
-                            csv_report,
-                            (
-                                os.path.basename(os.path.dirname(uuid_dir)),
-                                source_oe,
-                                accession_number_id,
-                                dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
-                                dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
-                                filename,
-                                unidecode.unidecode(series_title),
-                                unidecode.unidecode(prog_title),
-                                unidecode.unidecode(ep_num),
-                                checksum,
-                                mxf_checksum,
-                                'CHECKSUM MATCHES!'
-                                )
-                        )
-                    else:
-                        ififuncs.append_csv(
-                            csv_report,
-                            (
-                                os.path.basename(os.path.dirname(uuid_dir)),
-                                source_oe,
-                                accession_number_id,
-                                dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
-                                dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
-                                filename,
-                                unidecode.unidecode(series_title),
-                                unidecode.unidecode(prog_title),
-                                unidecode.unidecode(ep_num),
-                                checksum,
-                                mxf_checksum,
-                                'CHECKSUM DOES NOT MATCH!'
-                                )
-                        )
-                except AttributeError:
-                    ififuncs.append_csv(
-                        csv_report,
-                        (
-                            os.path.basename(os.path.dirname(uuid_dir)),
-                            source_oe,
-                            accession_number_id,
-                            dicto[os.path.basename(os.path.dirname(uuid_dir))][0],
-                            dicto[os.path.basename(os.path.dirname(uuid_dir))][1],
-                            filename,
-                            'error',
-                            'error',
-                            'error',
-                            'error',
-                            'error',
-                            'CHECKSUM DOES NOT MATCH!'
-                            )
-                        )
+            if xml_flag == 0:
+                print(dirpath + '\n*****There is no metadata xml file in the supplement directory!\n*****Check if the structure is correct.\n---')
+                continue
     print("Report complete - Time elaspsed : ", datetime.now() - startTime)
 
 


### PR DESCRIPTION
`AS11FIXITY.PY` Update:
1. Add block for *SIP/metadata/supplement/_MediaConchReport.xml* as it is recognised by the script by mistake.
Before:

| ID | oe | accessionnumber | files_count | directory_count | Filename | Series_Title | Prog_Title | Episode_Number | Md5_From_Xml | Md5_from_Mxf | Checksum_Result |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| oe12345 | oe12345| | 15 | 5 | RG-MP-GW001.mxf_MediaConchReport.xml | error | error | error | error | error | CHECKSUM DOES NOT MATCH! |
| oe12345 | oe12345| | 15 | 5 | RG-MP-GW001.mxl | $Title | Episode 1 | Episode 1 | cdc686ddb1a9f19c5b7d01a59ae7e121 | cdc686ddb1a9f19c5b7d01a59ae7e121 | CHECKSUM MATCHES! |

Now (the first row won't appear):

| ID | oe | accessionnumber | files_count | directory_count | Filename | Series_Title | Prog_Title | Episode_Number | Md5_From_Xml | Md5_from_Mxf | Checksum_Result |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| oe12345 | oe12345| | 15 | 5 | RG-MP-GW001.mxl | $Title | Episode 1 | Episode 1 | cdc686ddb1a9f19c5b7d01a59ae7e121 | cdc686ddb1a9f19c5b7d01a59ae7e121 | CHECKSUM MATCHES! |

2. Update code structure to store relative $vars at the first time when walking through every SIPs, such as *uuid, log*, etc.
3. Update code structure to locate the directory and files more accurate.
4. Update terminal prints with checksums and comparison result displayed:
Before:
```
C:\Users\Ingest_1>as11fixity.py D:\AS11fixitytest_sips\multi_test
{'oe16836': [15, 5], 'oe16837': [15, 5], 'oe26205': [15, 5]}
{'oe16836': [15, 5], 'oe16837': [15, 5], 'oe26205': [15, 5]} 12312312123
CSV file already exists.
cdc686ddb1a9f19c5b7d01a59ae7e121
Generating Report....

D:\AS11fixitytest_sips\multi_test\oe16836\b520403c-f7ed-44a0-817e-24d3bb1e2110\logs\b520403c-f7ed-44a0-817e-24d3bb1e2110_sip_log.log
481ee6e1a4b9f8183d93c29457cdc18e
Generating Report....

D:\AS11fixitytest_sips\multi_test\oe16837\e2babe38-9892-450b-a90e-33f5761ec5a2\logs\e2babe38-9892-450b-a90e-33f5761ec5a2_sip_log.log
481ee6e1a4b9f8183d93c29457cdc18e
Generating Report....

D:\AS11fixitytest_sips\multi_test\oe16837\e2babe38-9892-450b-a90e-33f5761ec5a2\logs\e2babe38-9892-450b-a90e-33f5761ec5a2_sip_log.log
{'oe16836': [15, 5], 'oe16837': [15, 5], 'oe26205': [15, 5]} 7897897897
2816c8c0c43de71263bcd5a8454e48b7
Generating Report....

D:\AS11fixitytest_sips\multi_test\oe26205\0c491f52-6108-41be-871f-1f531f613055\logs\0c491f52-6108-41be-871f-1f531f613055_sip_log.log
2816c8c0c43de71263bcd5a8454e48b7
Generating Report....

D:\AS11fixitytest_sips\multi_test\oe26205\0c491f52-6108-41be-871f-1f531f613055\logs\0c491f52-6108-41be-871f-1f531f613055_sip_log.log
{'oe16836': [15, 5], 'oe16837': [15, 5], 'oe26205': [15, 5]} 7897897897
Report complete - Time elaspsed :  0:00:00.067171
```

After (only error package shows path):
```
C:\Users\Ingest_1>as11fixity.py D:\AS11fixitytest_sips\multi_test
SIP/AIP found:
oe16836  | filecount:  15  | folder_count:  5
oe16837  | filecount:  15  | folder_count:  5
oe26205  | filecount:  15  | folder_count:  5

D:\AS11fixitytest_sips\multi_test\oe16836\b520403c-f7ed-44a0-817e-24d3bb1e2110\metadata\supplemental
*****There is no metadata xml file in the supplement directory!
*****Check if the structure is correct.
---
481ee6e1a4b9f8183d93c29457cdc18e - mxf checksum from package manifest
481ee6e1a4b9f8183d93c29457cdc18e - mxf checksum from DPP XML
Generating Report....
oe16837 Checksum MATCHES!
---
2816c8c0c43de71263bcd5a8454e48b7 - mxf checksum from package manifest
2816c8c0c43de71263bcd5a8454e48b7 - mxf checksum from DPP XML
Generating Report....
oe26205 Checksum MATCHES!
---
Report complete - Time elaspsed :  0:00:00.056142
```

















