### PR TITLE
merge_csv.py - new scripts - for merging csvs like helper_register

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,14 +94,14 @@ mergepbcore.py
 -  Usage ``mergepbcore.py /path/to/folder_that_contains_AIPs_as_input``
 -  Run ``mergepbcore.py -h`` for all options.
 
-mergecsv.py
+merge_csv.py
 ~~~~~~~~~~~~~~
 
 -  Collates CSV records into a single merged CSV.
 -  The merged csv will be stored in the Desktop ifiscripts_logs folder. There is no error checking.
--  This script takes a parent folder containing CSV files as input.
--  Usage ``mergecsv.py /path/to/folder_that_contains_csv_files``
--  Run ``mergecsv.py -h`` for all options.
+-  This script takes as many as CSV files with the same titles as needed as input.
+-  Usage ``merge_csv.py /path/to/csv_1 /path/to/csv_2 /path/to/csv_x``
+-  Run ``merge_csv.py -h`` for all options.
 
 deletefiles.py
 ~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ script-files=[
     'scripts/masscopy.py',
     'scripts/massqc.py',
     'scripts/mergepbcore.py',
+    'scripts/merge_csv.py',
     'scripts/multicopy.py',
     'scripts/normalise.py',
     'scripts/Objects.py',

--- a/scripts/merge_csv.py
+++ b/scripts/merge_csv.py
@@ -26,7 +26,7 @@ def parse_args(args_):
 def nameit():
     proceed = 'n'
     while proceed.lower() == 'n':
-        name_list = ['flimo_csv_merged',
+        name_list = ['filmo_csv_merged',
                     'pbcore_merged',
                     'sorted_merged',
                     'helper_register_merged',]
@@ -40,13 +40,33 @@ def nameit():
         try:
             index = int(user_input)-1
             name = name_list[index]
-            print('\nUser selected: ' + name_list[index])
+            print('\nName selected: ' + name_list[index])
         except ValueError:
             name = user_input
-            print('\nUser typed: ' + user_input)
+            print('\nName typed: ' + user_input)
         csv_name = time.strftime("%Y-%m-%dT%H_%M_%S_") + name + '.csv'
         proceed = ififuncs.ask_yes_no('Are you really sure? - The name will be:\n ' + csv_name)
     return csv_name
+
+def sortit(title_list):
+    title = ''
+    if title not in title_list:
+        print('\n\nSelect the index of the title in csv you want to sort by.')
+        i = 1
+        for item in title_list:
+            print('\t' + str(i) + '. ' + item)
+            i = i + 1
+        i = int(input('\n'))
+        while i > len(title_list) or i < 1:
+            print('\n\nSelect the index of the title in csv you want to sort by.')
+            i = 1
+            for item in title_list:
+                print('\t' + str(i) + '. ' + item)
+                i = i + 1
+            i = int(input('\n'))
+    title = title_list[i-1]
+    print('\nTitle selected: ' + title)
+    return title
 
 def main(args_):
     '''
@@ -60,7 +80,8 @@ def main(args_):
     print(*fieldname, sep=' | ')
     for file in csvs:
         data.extend(ififuncs.extract_metadata(file)[0])
-    data.sort(key=itemgetter(fieldname[0]))
+    title = sortit(fieldname)
+    data.sort(key=itemgetter(title))
     desktop_logs_dir = ififuncs.make_desktop_logs_dir()
     csv_name = nameit()
     new_csv = os.path.join(desktop_logs_dir, csv_name)

--- a/scripts/merge_csv.py
+++ b/scripts/merge_csv.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import csv
+import time
+import os
+import ififuncs
+from operator import itemgetter
+
+def parse_args(args_):
+    '''
+    Parse command line arguments.
+    '''
+    parser = argparse.ArgumentParser(
+        description='Merge helper accessions registers and sorted by object entry numbers.'
+        ' Merged register will be stored in the Desktop/ifiscripts_log.'
+        ' Written by Yazhou He.'
+    )
+    parser.add_argument(
+        'input', nargs='+'
+    )
+    parsed_args = parser.parse_args(args_)
+    return parsed_args
+
+def nameit():
+    proceed = 'n'
+    while proceed.lower() == 'n':
+        name_list = ['flimo_csv_merged',
+                    'pbcore_merged',
+                    'sorted_merged',
+                    'helper_register_merged',]
+        print('\n\nSelect the index of the name you want to use.\nType in the name if not in the list:\n')
+        i = 1
+        for item in name_list:
+            print('\t' + str(i) + '. ' + item)
+            i = i + 1
+        print()
+        user_input = input()
+        try:
+            index = int(user_input)-1
+            name = name_list[index]
+            print('\nUser selected: ' + name_list[index])
+        except ValueError:
+            name = user_input
+            print('\nUser typed: ' + user_input)
+        csv_name = time.strftime("%Y-%m-%dT%H_%M_%S_") + name + '.csv'
+        proceed = ififuncs.ask_yes_no('Are you really sure? - The name will be:\n ' + csv_name)
+    return csv_name
+
+def main(args_):
+    '''
+    Launches functions that will merge and sort helper accessions registers
+    '''
+    args = parse_args(args_)
+    csvs = args.input
+    data = []
+    fieldname = ififuncs.extract_metadata(csvs[0])[1]
+    print('CSV Title:', end=' ')
+    print(*fieldname, sep=' | ')
+    for file in csvs:
+        data.extend(ififuncs.extract_metadata(file)[0])
+    data.sort(key=itemgetter(fieldname[0]))
+    desktop_logs_dir = ififuncs.make_desktop_logs_dir()
+    csv_name = nameit()
+    new_csv = os.path.join(desktop_logs_dir, csv_name)
+    with open(new_csv, 'w', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldname)
+        writer.writeheader()
+        writer.writerows(data)
+    print('\nYour merged CSV file is located here: %s' % new_csv)
+    print('Comma/\',\' should be the only separator for this CSV. (Un-tick Semicolon/\';\' if it is selected.)')
+    return new_csv
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ NOTE: Objects.py has been copied from https://github.com/simsong/dfxml. walk_to_
         'scripts/masscopy.py',
         'scripts/massqc.py',
         'scripts/mergepbcore.py',
+        'scripts/merge_csv.py',
         'scripts/multicopy.py',
         'scripts/normalise.py',
         'scripts/Objects.py',


### PR DESCRIPTION
Features: Merge and sorted csvs.

Terminal view:
```
# merge_csv.py "D:\test\csv\1t2023-08-16T11_10_06_helper_register.csv" "D:\test\csv\2t2023-08-16T11_12_21_helper_register.csv"
CSV Title: entry number | accession number | date acquired | date accessioned | acquired from | acquisition method | simple name; basic description; identification; historical information | notes


Select the index of the name you want to use.
Type in the name if not in the list:

        1. flimo_csv_merged
        2. pbcore_merged
        3. sorted_merged
        4. helper_register_merged

4

User selected: helper_register_merged
 -
 Are you really sure? - The name will be:
 2023-08-16T12_20_45_helper_register_merged.csv
 enter Y or N
n


Select the index of the name you want to use.
Type in the name if not in the list:

        1. flimo_csv_merged
        2. pbcore_merged
        3. sorted_merged
        4. helper_register_merged

helper_register_merged_test

User typed: helper_register_merged_test
 -
 Are you really sure? - The name will be:
 2023-08-16T12_20_56_helper_register_merged_test.csv
 enter Y or N
y

Your merged CSV file is located here: C:\Users\hyz29/Desktop/ifiscripts_logs\2023-08-16T12_20_56_helper_register_merged_test.csv
Comma/',' should be the only separator for this CSV. (Un-tick Semicolon/';' if it is selected.)
```

Edited:
Added the feature to select a title for sorting CSVs after the csv name function.
```
Select the index of the title in csv you want to sort by.

        1. title_1
        2. title_2
...
```