### PR TITLE
get_ps_list.py, check_register.py - new scripts

### DIFF
--- a/scripts/check_register.py
+++ b/scripts/check_register.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import csv
+from collections import defaultdict
+import operator
+import argparse
+import sys
+import os
+import get_ps_list
+
+def parse_args(args_):
+    parser = argparse.ArgumentParser(
+        description='Check any mismatch on registers.'
+                    ' Written by Yazhou He.'
+    )
+    parser.add_argument(
+        '-preservation_storage_csv',
+        help='the correct mapping csv'
+    )
+    parser.add_argument(
+        '-register_csv',
+        help='the to-be-checked csv', required=True
+    )
+    parsed_args = parser.parse_args(args_)
+    return parsed_args
+
+def main(args_):
+    args = parse_args(args_)
+    file1 = args.preservation_storage_csv
+    file2 = args.register_csv
+
+    while not file1:
+        try:
+            ps_path = input('\nInput the path of preservation storage:\n\n')
+            file1 = get_ps_list.main(['-i', ps_path])
+        except:
+            file1 = ''
+            print('Cannot get list from input path.')
+
+    with open(file1, 'r', encoding='utf-8') as f1:
+        reader1 = csv.DictReader(f1)
+        mapping1 = defaultdict(list)
+        mapping2 = defaultdict(list)
+        for row in reader1:
+            mapping1[row['accession number']] = row['object entry number']
+            mapping2[row['object entry number']] = row['accession number']
+        mapping1 = dict(sorted(mapping1.items(), key=operator.itemgetter(0)))
+        mapping2 = dict(sorted(mapping2.items(), key=operator.itemgetter(0)))
+        
+    
+    with open(file2, 'r', encoding='utf-8') as f2:
+        reader2 = csv.DictReader(f2)
+        mapping3 = defaultdict(list)
+        mapping4 = defaultdict(list)
+        for row in reader2:
+            mapping3[row['accession number']].append(row['object entry number'])
+            mapping4[row['object entry number']].append(row['accession number'])
+        mapping3 = dict(sorted(mapping3.items(), key=operator.itemgetter(0)))
+        mapping4 = dict(sorted(mapping4.items(), key=operator.itemgetter(0)))
+    
+    csv1 = os.path.basename(file1)
+    csv2 = os.path.basename(file2)
+    
+    flag = True
+    # primary key: accession number
+    for key, values in mapping3.items():
+        if len(values) > 1:
+            print(f'In {csv2}, accession number {key} maps to multiple object entry number: {values}')
+            if key in mapping1:
+                correct_value = mapping1[key]
+                if correct_value in values:
+                    print(f'\tThe correct object entry number from {csv1} is: {correct_value}\n')
+                else:
+                    print(f'\tThe correct object entry number from {csv1} is not present in {csv2}\n')
+            flag = False
+        elif key in mapping1 and mapping1[key] != values[0]:
+            print(f'Mismatch: accession number {key} maps to {mapping1[key]} in {csv1} but maps to {values[0]} in {csv2}\n')
+            flag = False
+
+    # primary key: object entry number
+    for key, values in mapping4.items():
+        if len(values) > 1:
+            print(f'In {csv2}, object entry number {key} maps to multiple accession number: {values}')
+            if key in mapping2:
+                correct_value = mapping2[key]
+                if correct_value in values:
+                    print(f'\tThe correct accession number from {csv1} is: {correct_value}\n')
+                else:
+                    print(f'\tThe correct accession number from {csv1} is not present in {csv2}\n')
+            flag = False
+        elif key in mapping2 and mapping2[key] != values[0]:
+            print(f'Mismatch: object entry number {key} maps to {mapping2[key]} in {csv1} but maps to {values[0]} in {csv2}\n')
+            flag = False
+
+    if flag:
+        print(f'All values are matched between {csv1} and {csv2}')
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/scripts/get_ps_list.py
+++ b/scripts/get_ps_list.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import os
+import time
+import ififuncs
+import csv
+
+def parse_args(args_):
+    parser = argparse.ArgumentParser(
+        description='Get a CSV of AIPs in preservation storage with accession number and object entry number'
+					' Written by Yazhou He.'
+    )
+    parser.add_argument(
+        '-i',
+        help='root path of preservation_storage', required=True
+    )
+    parsed_args = parser.parse_args(args_)
+    return parsed_args
+
+def main(args_):
+	args = parse_args(args_)
+	package_list = os.listdir(args.i)
+	data=[]
+	for i in package_list:
+		package = os.path.join(args.i, i)
+		if os.path.isdir(package) and 'aaa' in package:
+			results={}
+			results['package'] = os.path.basename(package)
+			uuid_path = sorted(os.listdir(package))
+			for uuid_dir in uuid_path:
+				if len(uuid_dir)==36 and not uuid_dir.endswith('.txt') and not uuid_dir.endswith('.md5'):
+					log_dir = os.path.join(package, uuid_dir, 'logs')
+			logs = sorted(os.listdir(log_dir))
+			for log in logs:
+				if log.endswith('_seq2ffv1_log.log') or log.endswith('_sip_log.log'):
+					log_path = os.path.join(log_dir, log)
+					break
+				else:
+					log_path=''
+			if os.path.isfile(log_path):
+				with open(log_path, 'r', encoding='utf-8') as log_object:
+					log_lines = log_object.readlines()
+					for lines in log_lines:
+						if 'eventIdentifierType=accession number,' in lines:
+							aaa = lines.split('=')[-1].replace('\n', '')
+							results['accession number'] = aaa
+						if 'eventIdentifierType=object entry,' in lines or 'eventIdentifierType=object entry number,' in lines:
+							oe = lines.split('=')[-1].replace('\n', '')
+							results['object entry number'] = oe
+			data.append(results)
+		print('AIP found (filename): %s\tOE number (log): %s\tAccession number (log): %s' % (os.path.basename(package), oe, aaa), end = '\r')
+
+	desktop_logs_dir = ififuncs.make_desktop_logs_dir()
+	csv_name = time.strftime("%Y-%m-%dT%H_%M_%S_") + 'oe_aaa_map_ps.csv'
+	new_csv = os.path.join(desktop_logs_dir, csv_name)
+	fieldname = ['package', 'accession number', 'object entry number']
+	with open(new_csv, 'a', encoding='utf-8') as f:
+		writer = csv.DictWriter(f, fieldnames=fieldname)
+		writer.writeheader()
+		writer.writerows(data)
+	print('\nYour package list from preservation storage is located here: %s' % new_csv)
+	return new_csv
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
Two new Python scripts for checking if the records in the digital accession register/helper register match the files' logs in preservation storage.

`get_ps_list.py` is to get a CSV of all AIPs in preservation storage with accession number and object entry number. the information is got from the sip_log.log in each AIP/.../logs/.

`check_register.py` is to check any mismatch in the digital accession register/helper register by comparing the same accession number but different objects entry number, and the same object entry number but different accession number.

The scripts have been tested and applied in a project in the closing steps.