### PR TITLE
bitc.py - changed ffmpeg -filter_complex to -vf

### DIFF
--- a/scripts/bitc.py
+++ b/scripts/bitc.py
@@ -33,6 +33,8 @@ def set_options(args_):
     '''
     parser = argparse.ArgumentParser(
         description='IFI Irish Film Institute H264 FFMPEG Encoder.'
+                    ' In default, the watermark and timecode will be'
+                    ' added into the video track.'
         ' Written by Kieran O\'Leary.'
     )
     parser.add_argument(

--- a/scripts/bitc.py
+++ b/scripts/bitc.py
@@ -134,7 +134,9 @@ def build_filter(args, filename):
     if len(filtergraph) > 0:
         if filtergraph[-1] == ',':
             filtergraph = filtergraph[:-1]
-        filter_list = ['-filter_complex', filtergraph]
+        filter_list = ['-vf', filtergraph]
+        # changed from -filter_complex to -vf for ffmpeg v6.0
+        # filter_list = ['-filter_complex', filtergraph]
         print(filter_list)
     return filter_list
 


### PR DESCRIPTION
This is changed as the current command for ffmpeg 6.0 will burn the watermark or timecode in the video stream and create a new clean video track.
The change has been tested that it remains the only video track just like before.