### PR TITLE
seq2ffv1.py - check rawcooked process before run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     'bagit',
     'dicttoxml',
     'future',
-    'clairmeta'
+    'clairmeta',
+    'psutil'
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
add `clean_start()` for every `subprocess.call('rawcooked',...)` to avoid occasionally RawCooked freezing during script running.
It checks whether 'rawcooked' is in the pid list and kill it every time before run `subprocess.call()`.
This has been tested on Mac and worked fine.

Layout:
RAWcooked.exe process is in the back stage. Terminating it...
RAWcooked.exe process has been terminated. Ready to start running.
Ready for a clean start:
['rawcooked', '--check-padding', ......]