### PR TITLE
bitc.py - ffmpeg command fixed for logo option

### DIFF
--- a/scripts/bitc.py
+++ b/scripts/bitc.py
@@ -136,6 +136,7 @@ def build_filter(args, filename):
             filtergraph = filtergraph[:-1]
         if args.logo:
             filter_list = ['-filter_complex', filtergraph]
+            filter_list = filter_list + ['-disposition:v:0', 'default']
         else:
             filter_list = ['-vf', filtergraph]
         print(filter_list)

--- a/scripts/bitc.py
+++ b/scripts/bitc.py
@@ -119,7 +119,7 @@ def build_filter(args, filename):
     if args.yadif:
         h264_options.append('yadif')
     if args.logo:
-        h264_options.append('overlay=main_w-overlay_w-5:5')
+        h264_options.append('[0:v:0][1:v]overlay=main_w-overlay_w-5:5')
     if args.scale:
         h264_options.append('scale=%s' % args.scale)
         # width_height = args.scale
@@ -134,10 +134,10 @@ def build_filter(args, filename):
     if len(filtergraph) > 0:
         if filtergraph[-1] == ',':
             filtergraph = filtergraph[:-1]
-        filtergraph = '[0:v]' + filtergraph
-        filter_list = ['-vf', filtergraph]
-        # changed from -filter_complex to -vf for ffmpeg v6.0
-        # filter_list = ['-filter_complex', filtergraph]
+        if args.logo:
+            filter_list = ['-filter_complex', filtergraph]
+        else:
+            filter_list = ['-vf', filtergraph]
         print(filter_list)
     return filter_list
 


### PR DESCRIPTION
Fixed:
- logo option requires `-filter_complex` option to replace `-vf`.
```
[vf#0:0 @ 0x600003549680] Simple filtergraph 'overlay=main_w-overlay_w-5:5' was expected to have exactly 1 input and 1 output. However, it had 2 input(s) and 1 output(s). Please adjust, or use a complex filtergraph (-filter_complex) instead.
[vost#0:0/libx264 @ 0x126e08510] Error initializing a simple filtergraph
Error opening output file /Volumes/......_h264.mov.
Error opening output files: Invalid argument
```
- ffmpeg cannot locate stream from multiple streams (video and timecode mostly) in the input for overlay.
```
[fc#0 @ 0x600001824000] Cannot find a matching stream for unlabeled input pad overlay
Error binding filtergraph inputs/outputs: Invalid argument
```
- Output is generated with two video streams: one with logo and one without. And the default stream was set to the latter.